### PR TITLE
Permit middleware process_request to occur after routing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ below in order of date of first contribution:
 * Benjamen Meyer (BenjamenMeyer)
 * Sriram Madapusi Vasudevan (TheSriram)
 * Erik Erwitt (eerwitt)
+* Rahman Syed (rsyed83)


### PR DESCRIPTION
Change middleware behavior so that the presence of a middleware object field would enable process_request to happen after routing has occurred, while also providing access to the resource object.

Issue #400