### PR TITLE
feat(middleware): Add middleware method "process_resource"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ below in order of date of first contribution:
 * Sriram Madapusi Vasudevan (TheSriram)
 * Erik Erwitt (eerwitt)
 * Bernhard Weitzhofer (b6d)
+* Rahman Syed (rsyed83)

--- a/doc/api/middleware.rst
+++ b/doc/api/middleware.rst
@@ -1,0 +1,109 @@
+.. _middleware:
+
+Middleware
+==========
+
+Middleware components execute both before and after the framework
+routes the request.  Middleware is registered by passing components
+to the :ref:`API class <api>` initializer.
+
+The middleware interface is defined as follows:
+
+
+.. code:: python
+
+    class ExampleComponent(object):
+        def process_request(self, req, resp):
+            """Process the request before routing it.
+
+            Args:
+                req: Request object that will eventually be
+                    routed to an on_* responder method
+                resp: Response object that will be routed to
+                    the on_* responder
+            """
+
+        def process_resource(self, req, resp, resource):
+            """Process the request after routing.
+
+            Args:
+                req: Request object that will be passed to the
+                    routed responder
+                resp: Response object that will be passed to the
+                    responder
+                resource: Resource object to which the request was
+                    routed. May be None if no route was found for
+                    the request
+            """
+
+        def process_response(self, req, resp, resource)
+            """Post-processing of the response (after routing).
+
+            Args:
+                req: Request object
+                resp: Response object
+                resource: Resource object to which the request was
+                    routed. May be None if no route was found
+                    for the request
+            """
+
+Because middleware can execute before routing has occurred, if a
+component modifies ``req.uri`` in its *process_request* method,
+the framework will use the modified value to route the request.
+
+Each component's *process_request*, *process_resource*, and
+*process_response* methods are executed hierarchically, as a stack.
+For example, if a list of middleware objects are passed as
+``[mob1, mob2, mob3]``, the order of execution is as follows::
+
+    mob1.process_request
+        mob2.process_request
+            mob3.process_request
+                mob1.process_resource
+                    mob2.process_resource
+                        mob3.process_resource
+                <route to responder method>
+            mob3.process_response
+        mob2.process_response
+    mob1.process_response
+
+Note that each component need not implement all process_*
+methods; in the case that one of the three methods is missing,
+it is treated as a noop in the stack. For example, if ``mob2`` did
+not implement *process_request* and ``mob3`` did not implement
+*process_response*, the execution order would look
+like this::
+
+    mob1.process_request
+        _
+            mob3.process_request
+                mob1.process_resource
+                    mob2.process_resource
+                        mob3.process_resource
+                <route to responder method>
+            _
+        mob2.process_response
+    mob1.process_response
+
+If one of the *process_request* middleware methods raises an
+error, it will be processed according to the error type. If
+the type matches a registered error handler, that handler will
+be invoked and then the framework will begin to unwind the
+stack, skipping any lower layers. The error handler may itself
+raise an instance of HTTPError, in which case the framework
+will use the latter exception to update the *resp* object.
+Regardless, the framework will continue unwinding the middleware
+stack. For example, if *mob2.process_request* were to raise an
+error, the framework would execute the stack as follows::
+
+    mob1.process_request
+        mob2.process_request
+            <skip mob1/mob2 process_resource, mob3, and routing>
+        mob2.process_response
+    mob1.process_response
+
+Finally, if one of the *process_response* methods raises an error,
+or the routed on_* responder method itself raises an error, the
+exception will be handled in a similar manner as above. Then,
+the framework will execute any remaining middleware on the
+stack.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -115,7 +115,7 @@ Classes and Functions
    api/request_and_response
    api/status
    api/errors
+   api/middleware
    api/hooks
    api/routing
    api/util
-

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -50,14 +50,17 @@ def prepare_middleware(middleware=None):
     for component in middleware:
         process_request = util.get_bound_method(component,
                                                 'process_request')
+        process_resource = util.get_bound_method(component,
+                                                 'process_resource')
         process_response = util.get_bound_method(component,
                                                  'process_response')
 
-        if not (process_request or process_response):
+        if not (process_request or process_resource or process_response):
             msg = '{0} does not implement the middleware interface'
             raise TypeError(msg.format(component))
 
-        prepared_middleware.append((process_request, process_response))
+        prepared_middleware.append((process_request, process_resource,
+                                    process_response))
 
     return prepared_middleware
 

--- a/falcon/bench/queues/api.py
+++ b/falcon/bench/queues/api.py
@@ -25,7 +25,7 @@ class RequestIDComponent(object):
     def process_request(self, req, resp):
         req.context['request_id'] = '<generate ID>'
 
-    def process_response(self, req, resp):
+    def process_response(self, req, resp, resource):
         resp.set_header('X-Request-ID', req.context['request_id'])
 
 


### PR DESCRIPTION
Create a new middleware method process_resource that occurs after process_request and routing, and ensure that the resource object is accessible. Additionally, make the resource object available to process_response.

Issue #400 