### PR TITLE
fix(HTTPError): Correct typo in default link text, make more generic

### DIFF
--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -102,7 +102,7 @@ class HTTPError(Exception):
 
         if href:
             link = self.link = OrderedDict()
-            link['text'] = (href_text or 'API documention for this error')
+            link['text'] = (href_text or 'Documentation related to this error')
             link['href'] = uri.encode(href)
             link['rel'] = 'help'
         else:

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -341,7 +341,7 @@ class TestHTTPError(testing.TestBase):
             'description': ('You do not have write permissions for this '
                             'queue.'),
             'link': {
-                'text': 'API documention for this error',
+                'text': 'Documentation related to this error',
                 'href': 'http://example.com/api/rbac',
                 'rel': 'help',
             },


### PR DESCRIPTION
Correct the link text typo "documention" to "documentation". Also make the text more generic by removing the reference to "API".