### PR TITLE
docs: Change complex example to match new middleware feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ class JSONTranslator(object):
                                    'JSON was incorrect or not encoded as '
                                    'UTF-8.')
 
-    def process_response(self, req, resp):
+    def process_response(self, req, resp, resource):
         if 'result' not in req.context:
             return
 

--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ Here is a more involved example that demonstrates reading headers and query para
                                        'JSON was incorrect or not encoded as '
                                        'UTF-8.')
 
-        def process_response(self, req, resp):
+        def process_response(self, req, resp, resource):
             if 'result' not in req.context:
                 return
 

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -114,7 +114,7 @@ class JSONTranslator(object):
                                    'JSON was incorrect or not encoded as '
                                    'UTF-8.')
 
-    def process_response(self, req, resp):
+    def process_response(self, req, resp, resource):
         if 'result' not in req.context:
             return
 


### PR DESCRIPTION
The `process_response` method of `JSONTranslator` is missing the
`resource` argument in order to fully comply with the new middleware
feature.

Closes #443